### PR TITLE
Fix `ValueError` in Python 3.8 or newer

### DIFF
--- a/test/test_utils/test_message.py
+++ b/test/test_utils/test_message.py
@@ -23,7 +23,7 @@ class UserMessageHandlerTestCase(unittest.TestCase):
     def test_init_w_formatter(self, m_errormsg):
         logger = logging.getLogger('test_init_w_formatter')
         format_string = 'a really silly format that discards the actual message'
-        handler = message.UserMessageHandler(logging.Formatter(format_string))
+        handler = message.UserMessageHandler(logging.Formatter(format_string, validate=False))
         logger.addHandler(handler)
 
         logger.info("WEEEOOOWEEEOOOWEEEOOO")


### PR DESCRIPTION
Validation has become stricter in Python 3.8.
So we need to pass `validate=False` to the constructor in this one case, lest Python will print the following error message:

> ValueError: Invalid format 'a really silly format that discards the actual message' for '%' style
