### PR TITLE
Remove `test` modules from sdist, wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     long_description_content_type='text/markdown',
     url='https://github.com/evil-mad/ink_extensions',
 
-    packages=find_packages(exclude=['contrib', 'docs', 'tests']),
+    packages=find_packages(exclude=['contrib', 'docs', 'test', 'test.*']),
     install_requires=[
         'lxml'
     ],


### PR DESCRIPTION
I think the `test` modules are not supposed to be included in the sdist and wheels.
