### PR TITLE
Fix assertions that had no effect

### DIFF
--- a/test/test_utils/test_message.py
+++ b/test/test_utils/test_message.py
@@ -18,7 +18,7 @@ class UserMessageHandlerTestCase(unittest.TestCase):
 
         logger.info(a_message)
 
-        m_errormsg.error_msg.called_once_with(a_message) # message is unchanged (default formatter)
+        m_errormsg.error_msg.assert_called_once_with(a_message) # message is unchanged (default formatter)
 
     def test_init_w_formatter(self, m_errormsg):
         logger = logging.getLogger('test_init_w_formatter')
@@ -28,7 +28,7 @@ class UserMessageHandlerTestCase(unittest.TestCase):
 
         logger.info("WEEEOOOWEEEOOOWEEEOOO")
 
-        m_errormsg.error_msg.called_once_with(format_string)
+        m_errormsg.error_msg.assert_called_once_with(format_string)
 
     @patch.object(message.UserMessageHandler, "format")
     @patch.object(message, "emit")

--- a/test/test_utils/test_message.py
+++ b/test/test_utils/test_message.py
@@ -7,32 +7,33 @@ from ink_extensions_utils import message
 
 # python -m unittest discover in top-level package dir
 
-@patch.object(message.inkex, "errormsg")
+@patch.object(message, "emit")
 class UserMessageHandlerTestCase(unittest.TestCase):
 
-    def test_init(self, m_errormsg):
+    def test_init(self, m_emit):
         logger = logging.getLogger('test_init')
         a_message = "a message"        
         handler = message.UserMessageHandler()
         logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
 
         logger.info(a_message)
 
-        m_errormsg.error_msg.assert_called_once_with(a_message) # message is unchanged (default formatter)
+        m_emit.assert_called_once_with(a_message) # message is unchanged (default formatter)
 
-    def test_init_w_formatter(self, m_errormsg):
+    def test_init_w_formatter(self, m_emit):
         logger = logging.getLogger('test_init_w_formatter')
         format_string = 'a really silly format that discards the actual message'
         handler = message.UserMessageHandler(logging.Formatter(format_string, validate=False))
         logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
 
         logger.info("WEEEOOOWEEEOOOWEEEOOO")
 
-        m_errormsg.error_msg.assert_called_once_with(format_string)
+        m_emit.assert_called_once_with(format_string)
 
     @patch.object(message.UserMessageHandler, "format")
-    @patch.object(message, "emit")
-    def test_handler(self, m_emit, m_format, m_errormsg):
+    def test_handler(self, m_format, m_emit):
         handler = message.UserMessageHandler()
         a_message = "a message"
         record = logging.LogRecord("", 0, "", 0, a_message, {}, {})


### PR DESCRIPTION
## Assertions that have no effect

In a mock object, there is no assertion method named `called_once_with`.

Because the object is mocked, the non-existing method would get called but have no effect, making the tests silently pass.

This PR replaces affected calls with `assert_called_once_with`, which gives the tests their teeth back.

## Errors uncovered by fixing the assertions

Fixing the assertions revealed more underlying errors:

1. Mocking `inkex.errormsg` has no effect because the code in `message.py` keeps its own reference to `inkex.errormsg`, which it saved to the `emit` alias before patching occurs. This causes the code in `message.py` to bypass the mock object altogether.

2. The `INFO` log level is not enabled by default, so the logging handler filters the message out.

Both 1. and 2. caused the tests to fail.
(You can check out commit 07c89ec and run `pytest` to see for yourself.)

## Fixing the errors

In addition to fixing the assertions, this PR fixes error number 1 by mocking `message.emit` directly instead of `inkex.errormsg`.

This PR also fixes the second error by enabling the `INFO` log level so the logging handler actually lets the message through.
