### PR TITLE
Fix regexp syntax warning/popup

### DIFF
--- a/ink_extensions/simpletransform.py
+++ b/ink_extensions/simpletransform.py
@@ -27,7 +27,7 @@ def parseTransform(transf,mat=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]):
     if transf=="" or transf==None:
         return(mat)
     stransf = transf.strip()
-    result=re.match("(translate|scale|rotate|skewX|skewY|matrix)\s*\(([^)]*)\)\s*,?",stransf)
+    result=re.match(r"(translate|scale|rotate|skewX|skewY|matrix)\s*\(([^)]*)\)\s*,?",stransf)
 #-- translate --
     if result.group(1)=="translate":
         args=result.group(2).replace(',',' ').split()


### PR DESCRIPTION
When running under Python v3.12, the `re.match` invocation in `simpletransform.py` causes a syntax warning, because the regexp string contains an escape sequence that Python tries to interpret as part of the string literal:

```bash
python -c 'import re; print(re.match("(translate|scale|rotate|skewX|skewY|matrix)\s*\(([^)]*)\)\s*,?", "translate(3.1416)"))'
<string>:1: SyntaxWarning: invalid escape sequence '\s'
<re.Match object; span=(0, 17), match='translate(3.1416)'>
```

The warning disrupts the UX because Inkscape presents it in a popup every time that part of the code runs:

![image](https://github.com/evil-mad/ink_extensions/assets/1239874/aa48fa7b-74a9-466a-8299-95201c20b8de)

The `\s` is really meant to be taken literally and to be passed to the regexp engine as is.  
This PR replaces the string with a raw string to achieve that.
