### PR TITLE
use standard import statements (relative imports)

### DIFF
--- a/ink_extensions/cspsubdiv.py
+++ b/ink_extensions/cspsubdiv.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-from bezmisc import *
-from ffgeom import *
+from .bezmisc import *
+from .ffgeom import *
 
 def maxdist(input):
     ((p0x,p0y),(p1x,p1y),(p2x,p2y),(p3x,p3y))=input

--- a/ink_extensions/cubicsuperpath.py
+++ b/ink_extensions/cubicsuperpath.py
@@ -19,7 +19,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 """
-import simplepath 
+from . import simplepath
 from math import *
 
 def matprod(mlist):

--- a/ink_extensions/simpletransform.py
+++ b/ink_extensions/simpletransform.py
@@ -20,7 +20,7 @@ barraud@math.univ-lille1.fr
 This code defines several functions to make handling of transform
 attribute easier.
 '''
-import inkex, cubicsuperpath, bezmisc, simplestyle
+from . import inkex, cubicsuperpath, bezmisc, simplestyle
 import copy, math, re
 
 def parseTransform(transf,mat=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ink_extensions',
-    version='2.0.0',
+    version='2.1.0',
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/evil-mad/ink_extensions',


### PR DESCRIPTION
This is necessary for the pyinstaller build of the merge CLI to work. To check that these changes don't break anything, I ran it through all our workflows and tested it through inkscape on my machine. It appears not to break anything. I do wonder if there's a reason to keep the import statements unchanged though. @oskay 